### PR TITLE
Chore: Update KCC triggering conditions

### DIFF
--- a/packages/api/src/dataFeedsRouter.json
+++ b/packages/api/src/dataFeedsRouter.json
@@ -341,21 +341,21 @@
           "feeds": {
             "Price-KCS/USDT-6": {
               "label": "₮",
-              "deviationPercentage": 1.0,
-              "maxSecsBetweenUpdates": 86400,
-              "minSecsBetweenUpdates": 3600
+              "deviationPercentage": 0.5,
+              "maxSecsBetweenUpdates": 600,
+              "minSecsBetweenUpdates": 240
             },
             "Price-BTC/USD-6": {
               "label": "$",
-              "deviationPercentage": 3.5,
-              "maxSecsBetweenUpdates": 86400,
-              "minSecsBetweenUpdates": 3600
+              "deviationPercentage": 0.5,
+              "maxSecsBetweenUpdates": 600,
+              "minSecsBetweenUpdates": 240
             },
             "Price-ETH/USD-6": {
               "label": "$",
-              "deviationPercentage": 3.5,
-              "maxSecsBetweenUpdates": 86400,
-              "minSecsBetweenUpdates": 3600
+              "deviationPercentage": 0.5,
+              "maxSecsBetweenUpdates": 600,
+              "minSecsBetweenUpdates": 240
             }
           }
         }

--- a/packages/api/src/dataFeedsRouter.json
+++ b/packages/api/src/dataFeedsRouter.json
@@ -314,21 +314,21 @@
           "feeds": {
             "Price-KCS/USDT-6": {
               "label": "₮",
-              "deviationPercentage": 1.0,
-              "maxSecsBetweenUpdates": 3600,
-              "minSecsBetweenUpdates": 300
+              "deviationPercentage": 0.5,
+              "maxSecsBetweenUpdates": 600,
+              "minSecsBetweenUpdates": 240
             },
             "Price-BTC/USD-6": {
               "label": "$",
-              "deviationPercentage": 1.0,
-              "maxSecsBetweenUpdates": 3600,
-              "minSecsBetweenUpdates": 300
+              "deviationPercentage": 0.5,
+              "maxSecsBetweenUpdates": 600,
+              "minSecsBetweenUpdates": 240
             },
             "Price-ETH/USD-6": {
               "label": "$",
-              "deviationPercentage": 1.0,
-              "maxSecsBetweenUpdates": 3600,
-              "minSecsBetweenUpdates": 300
+              "deviationPercentage": 0.5,
+              "maxSecsBetweenUpdates": 600,
+              "minSecsBetweenUpdates": 240
             }
           }
         },

--- a/packages/api/src/dataFeedsRouter.json
+++ b/packages/api/src/dataFeedsRouter.json
@@ -192,7 +192,7 @@
             "Price-CFX/USDT-6": {
               "label": "₮",
               "deviationPercentage": 1.0,
-              "maxSecsBetweenUpdates": 86400,
+              "maxSecsBetweenUpdates": 3600,
               "minSecsBetweenUpdates": 900
             },
             "Price-BTC/USD-6": {


### PR DESCRIPTION
Set triggering conditions of BTC/USD-6, ETH/USD-6 and KCS/USDT-6 to:
- Deviation: 0.5 %
- Heartbeat: 10 minutes
- Cooldown: 240 seconds

In both testnet and mainnet.