### PR TITLE
fix(api): avoid search data without and index

### DIFF
--- a/packages/api/src/repository/ResultRequest.ts
+++ b/packages/api/src/repository/ResultRequest.ts
@@ -69,10 +69,6 @@ export class ResultRequestRepository {
         sort: {
           timestamp: -1
         },
-        collation: {
-          locale: 'en_US',
-          numericOrdering: true
-        }
       }
     )
     return this.normalizeId(lastResultRequest)


### PR DESCRIPTION
Remove collation option when getting the last result of a feed. That collation option was delaying the query because the resulting filter was looking for data that was not sorted by an existed index

close #131 