### PR TITLE
ci: add lint:check script to run on github actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - run: yarn
       - run: yarn bootstrap
-      - run: yarn lint
+      - run: yarn lint:check
 
       - run: yarn test
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": "yarn lerna run build --stream --concurrency 1",
     "test": "yarn lerna run test --stream ",
     "lint": "yarn lerna run lint --stream --concurrency 1",
+    "lint:check": "yarn lerna run lint:check --stream --concurrency 1",
     "clean": "yarn lerna run clean --concurrency 4",
     "prepare": "lerna run prepare",
     "docker:build": "lerna run docker:build"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -7,6 +7,7 @@
     "build": "tsc -p tsconfig.build.json",
     "codegen": "graphql-codegen --config ./codegen.yml",
     "lint": "prettier-standard --format",
+    "lint:check": "prettier-standard --check",
     "dev": "nodemon",
     "start": "node dist/index.js",
     "test": "jest",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,9 +7,12 @@
     "start": "nuxt start",
     "generate": "nuxt generate",
     "lint:js": "eslint --ext \".js,.vue\" . --fix",
+    "lint:js:check": "eslint --ext \".js,.vue\" .",
     "i18n:report": "yarn run vue-i18n-extract use-config",
     "lint:style": "stylelint \"**/*.{vue,css}\" --fix",
+    "lint:style:check": "stylelint \"**/*.{vue,css}\"",
     "lint": "yarn lint:js && yarn lint:style",
+    "lint:check": "yarn lint:js:check && yarn lint:style",
     "test": "yarn jest",
     "docker:build": "docker build . --no-cache -t witnet/data-feeds-explorer-ui"
   },


### PR DESCRIPTION
Before this change, the ci workflow couldn't detect if the code was formatted.
Now the workflow runs `yarn lint:check` and fails if an error is detected.