### PR TITLE
chore: add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+* text=auto
+
+# Overwrite the above and declare files that will always have
+# LF line endings on checkin and checkout 
+*.env text eol=lf
+*.gql text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.scss text eol=lf
+*.sh text eol=lf
+*.svgtext eol=lf
+*.ts text eol=lf
+*.vue text eol=lf
+*.xml text eol=lf
+*.yml text eol=lf
+
+*.png binary
+*.jpg binary
+*.ico binary


### PR DESCRIPTION
Avoid git warnings after run the linter in windows specifing the end of line type  or each file extension