### PR TITLE
fix(api): avoid overwrite values when calling refreshV2NetworkFeeds

### DIFF
--- a/packages/api/src/repository/Feed.ts
+++ b/packages/api/src/repository/Feed.ts
@@ -81,9 +81,7 @@ export class FeedRepository {
     const v2Feeds = this.feedsState.getV2Feeds()
 
     const newV2Feeds = v2Feeds
-      .filter((feed) => {
-        feed.network !== network
-      })
+      .filter((feed) => feed.network !== network)
       .concat(feedInfos)
 
     this.feedsState.setV2Feeds(newV2Feeds)

--- a/packages/api/test/repository/feed.spec.ts
+++ b/packages/api/test/repository/feed.spec.ts
@@ -827,4 +827,20 @@ describe('FeedRepository', () => {
     expect(updatedConfig).toStrictEqual(feedRepository.getConfigByFullName())
     expect(updatedConfig).not.toStrictEqual(baseConfigFullName)
   })
+
+  it('refreshV2NetworkFeeds concats new values in the state instead of overwrite them', () => {
+    const feedState = new FeedsState()
+
+    feedState.setLegacyFeeds(legacyFeeds)
+    feedState.setV2Feeds(v2Feeds)
+
+    const feedRepository = new FeedRepository(feedState)
+
+    feedRepository.refreshV2NetworkFeeds(v2Feed.network, [v2Feed])
+
+    expect(feedRepository.feedsState.getV2Feeds()).toStrictEqual([
+      ...v2Feeds,
+      v2Feed,
+    ])
+  })
 })


### PR DESCRIPTION
We were overwriting the values in the internal state because we weren't returning any value inside the filter function.